### PR TITLE
Throw an error in case of config conflict (rosetta offline mode)

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -438,10 +438,10 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 	if config.Rosetta.Enable {
 		offlineMode := config.Rosetta.Offline
 
-		// If GRPC is not enabled rosetta cannot work in online mode, so it works in
-		// offline mode.
-		if !config.GRPC.Enable {
-			offlineMode = true
+		// If GRPC is not enabled rosetta cannot work in online mode, so we throw an error.
+		if !config.GRPC.Enable && !offlineMode {
+			return fmt.Errorf("'grpc' must be enable in online mode for Rosetta to work.")
+
 		}
 
 		minGasPrices, err := sdktypes.ParseDecCoins(config.MinGasPrices)


### PR DESCRIPTION
Change the strategy where the service start in offline mode instead of throwing an error message in case of conflict in configurations.

<!-- ClickUpRef: 31axr7n -->
:link: [zboto Link](https://app.clickup.com/t/31axr7n)