### PR TITLE
Fix blockidentifier not specify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.18
+go 1.19
 
 module github.com/cosmos/cosmos-sdk
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.19
+go 1.18
 
 module github.com/cosmos/cosmos-sdk
 
@@ -14,7 +14,6 @@ require (
 	github.com/btcsuite/btcd v0.22.1
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/cockroachdb/apd/v2 v2.0.2
-	github.com/coinbase/rosetta-sdk-go v0.8.1
 	github.com/confio/ics23/go v0.7.0
 	github.com/cosmos/btcutil v1.0.4
 	github.com/cosmos/cosmos-proto v1.0.0-alpha7
@@ -77,6 +76,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/coinbase/rosetta-sdk-go v0.8.1 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/ledger-go v0.9.2 // indirect
 	github.com/creachadair/taskgroup v0.3.2 // indirect
@@ -160,6 +160,7 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+	github.com/coinbase/rosetta-sdk-go => github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a
 	github.com/cosmos/cosmos-sdk/rosetta => ./server/rosetta
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/cockroachdb/apd/v2 v2.0.2/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOG
 github.com/cockroachdb/apd/v3 v3.1.0 h1:MK3Ow7LH0W8zkd5GMKA1PvS9qG3bWFI95WaVNfyZJ/w=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/coinbase/rosetta-sdk-go v0.8.1 h1:WE+Temc8iz7Ra7sCpV9ymBJx78vItqFJ2xcSiPet1Pc=
-github.com/coinbase/rosetta-sdk-go v0.8.1/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
+github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a h1:tAQukG4KWS+9jBQs/lkFfKfONI01QJ1YoxnjzHAEh88=
+github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
 github.com/confio/ics23/go v0.7.0 h1:00d2kukk7sPoHWL4zZBZwzxnpA2pec1NPdwbSokJ5w8=
 github.com/confio/ics23/go v0.7.0/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=

--- a/server/rosetta/go.mod
+++ b/server/rosetta/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	cosmossdk.io/math v1.0.0-beta.3
 	github.com/btcsuite/btcd v0.22.1
-	github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a
+	github.com/coinbase/rosetta-sdk-go v0.8.1
 	github.com/cosmos/cosmos-sdk v0.46.1
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
@@ -108,4 +108,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+replace (
+	github.com/coinbase/rosetta-sdk-go => github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a
+	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+)

--- a/server/rosetta/go.mod
+++ b/server/rosetta/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/rosetta
 
-go 1.18
+go 1.19
 
 require (
 	cosmossdk.io/math v1.0.0-beta.3

--- a/server/rosetta/go.mod
+++ b/server/rosetta/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	cosmossdk.io/math v1.0.0-beta.3
 	github.com/btcsuite/btcd v0.22.1
-	github.com/coinbase/rosetta-sdk-go v0.8.0
+	github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a
 	github.com/cosmos/cosmos-sdk v0.46.1
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5

--- a/server/rosetta/go.sum
+++ b/server/rosetta/go.sum
@@ -113,8 +113,8 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd/v2 v2.0.2 h1:weh8u7Cneje73dDh+2tEVLUvyBc89iwepWCD8b8034E=
-github.com/coinbase/rosetta-sdk-go v0.8.0 h1:FXootIYNrQyVbpGfWfmEOBzEGKku8Wuyql+iyIy3L+g=
-github.com/coinbase/rosetta-sdk-go v0.8.0/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
+github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a h1:tAQukG4KWS+9jBQs/lkFfKfONI01QJ1YoxnjzHAEh88=
+github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
 github.com/confio/ics23/go v0.7.0 h1:00d2kukk7sPoHWL4zZBZwzxnpA2pec1NPdwbSokJ5w8=
 github.com/confio/ics23/go v0.7.0/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/server/rosetta/lib/internal/service/data.go
+++ b/server/rosetta/lib/internal/service/data.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/cosmos/cosmos-sdk/rosetta/lib/errors"

--- a/server/rosetta/lib/internal/service/data.go
+++ b/server/rosetta/lib/internal/service/data.go
@@ -21,8 +21,6 @@ func (on OnlineNetwork) AccountBalance(ctx context.Context, request *types.Accou
 
 	switch {
 	case request.BlockIdentifier == nil:
-		fmt.Println("No block identifier")
-
 		syncStatus, err := on.client.Status(ctx)
 		if err != nil {
 			return nil, errors.ToRosetta(err)
@@ -32,17 +30,12 @@ func (on OnlineNetwork) AccountBalance(ctx context.Context, request *types.Accou
 			return nil, errors.ToRosetta(err)
 		}
 	case request.BlockIdentifier.Hash != nil:
-		fmt.Println("We have block identifier hash")
-
 		block, err = on.client.BlockByHash(ctx, *request.BlockIdentifier.Hash)
 		if err != nil {
 			return nil, errors.ToRosetta(err)
 		}
 		height = block.Block.Index
 	case request.BlockIdentifier.Index != nil:
-		fmt.Println("We have a block identifier index")
-		fmt.Println(*request.BlockIdentifier.Index)
-
 		height = *request.BlockIdentifier.Index
 		block, err = on.client.BlockByHeight(ctx, &height)
 		if err != nil {
@@ -55,9 +48,6 @@ func (on OnlineNetwork) AccountBalance(ctx context.Context, request *types.Accou
 		return nil, errors.ToRosetta(err)
 	}
 
-	s, _ := json.Marshal(accountCoins)
-	fmt.Println(s)
-
 	return &types.AccountBalanceResponse{
 		BlockIdentifier: block.Block,
 		Balances:        accountCoins,
@@ -67,7 +57,6 @@ func (on OnlineNetwork) AccountBalance(ctx context.Context, request *types.Accou
 
 // Block gets the transactions in the given block
 func (on OnlineNetwork) Block(ctx context.Context, request *types.BlockRequest) (*types.BlockResponse, *types.Error) {
-	fmt.Println("Calling /block")
 	var (
 		blockResponse crgtypes.BlockTransactionsResponse
 		err           error
@@ -93,7 +82,6 @@ func (on OnlineNetwork) Block(ctx context.Context, request *types.BlockRequest) 
 
 	default:
 		// both empty
-		fmt.Println("Both empty - we do current height")
 		blockResponse, err = on.client.BlockTransactionsByHeight(ctx, nil)
 		if err != nil {
 			return nil, errors.ToRosetta(err)
@@ -126,7 +114,6 @@ func (on OnlineNetwork) Block(ctx context.Context, request *types.BlockRequest) 
 // BlockTransaction gets the given transaction in the specified block, we do not need to check the block itself too
 // due to the fact that tendermint achieves instant finality
 func (on OnlineNetwork) BlockTransaction(ctx context.Context, request *types.BlockTransactionRequest) (*types.BlockTransactionResponse, *types.Error) {
-	fmt.Printf("Calling /block/transaction")
 	tx, err := on.client.GetTx(ctx, request.TransactionIdentifier.Hash)
 	if err != nil {
 		return nil, errors.ToRosetta(err)
@@ -163,7 +150,6 @@ func (on OnlineNetwork) MempoolTransaction(ctx context.Context, request *types.M
 }
 
 func (on OnlineNetwork) NetworkList(_ context.Context, _ *types.MetadataRequest) (*types.NetworkListResponse, *types.Error) {
-	fmt.Println("/network/list")
 	return &types.NetworkListResponse{NetworkIdentifiers: []*types.NetworkIdentifier{on.network}}, nil
 }
 
@@ -172,7 +158,6 @@ func (on OnlineNetwork) NetworkOptions(_ context.Context, _ *types.NetworkReques
 }
 
 func (on OnlineNetwork) NetworkStatus(ctx context.Context, _ *types.NetworkRequest) (*types.NetworkStatusResponse, *types.Error) {
-	fmt.Printf("/network/status")
 	syncStatus, err := on.client.Status(ctx)
 	if err != nil {
 		return nil, errors.ToRosetta(err)

--- a/server/rosetta/lib/internal/service/data.go
+++ b/server/rosetta/lib/internal/service/data.go
@@ -67,6 +67,7 @@ func (on OnlineNetwork) AccountBalance(ctx context.Context, request *types.Accou
 
 // Block gets the transactions in the given block
 func (on OnlineNetwork) Block(ctx context.Context, request *types.BlockRequest) (*types.BlockResponse, *types.Error) {
+	fmt.Println("Calling /block")
 	var (
 		blockResponse crgtypes.BlockTransactionsResponse
 		err           error
@@ -92,6 +93,7 @@ func (on OnlineNetwork) Block(ctx context.Context, request *types.BlockRequest) 
 
 	default:
 		// both empty
+		fmt.Println("Both empty - we do current height")
 		blockResponse, err = on.client.BlockTransactionsByHeight(ctx, nil)
 		if err != nil {
 			return nil, errors.ToRosetta(err)
@@ -124,6 +126,7 @@ func (on OnlineNetwork) Block(ctx context.Context, request *types.BlockRequest) 
 // BlockTransaction gets the given transaction in the specified block, we do not need to check the block itself too
 // due to the fact that tendermint achieves instant finality
 func (on OnlineNetwork) BlockTransaction(ctx context.Context, request *types.BlockTransactionRequest) (*types.BlockTransactionResponse, *types.Error) {
+	fmt.Printf("Calling /block/transaction")
 	tx, err := on.client.GetTx(ctx, request.TransactionIdentifier.Hash)
 	if err != nil {
 		return nil, errors.ToRosetta(err)
@@ -160,6 +163,7 @@ func (on OnlineNetwork) MempoolTransaction(ctx context.Context, request *types.M
 }
 
 func (on OnlineNetwork) NetworkList(_ context.Context, _ *types.MetadataRequest) (*types.NetworkListResponse, *types.Error) {
+	fmt.Println("/network/list")
 	return &types.NetworkListResponse{NetworkIdentifiers: []*types.NetworkIdentifier{on.network}}, nil
 }
 
@@ -168,6 +172,7 @@ func (on OnlineNetwork) NetworkOptions(_ context.Context, _ *types.NetworkReques
 }
 
 func (on OnlineNetwork) NetworkStatus(ctx context.Context, _ *types.NetworkRequest) (*types.NetworkStatusResponse, *types.Error) {
+	fmt.Printf("/network/status")
 	syncStatus, err := on.client.Status(ctx)
 	if err != nil {
 		return nil, errors.ToRosetta(err)

--- a/server/rosetta/lib/internal/service/online.go
+++ b/server/rosetta/lib/internal/service/online.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"time"
-	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 

--- a/server/rosetta/lib/internal/service/online.go
+++ b/server/rosetta/lib/internal/service/online.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"time"
+	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 
@@ -24,6 +25,8 @@ func NewOnlineNetwork(network *types.NetworkIdentifier, client crgtypes.Client) 
 	if err != nil {
 		return OnlineNetwork{}, err
 	}*/
+
+	fmt.Println("What")
 
 	block := types.BlockIdentifier{
 		Index: 9283650, // Theta upgrade height

--- a/server/rosetta/lib/internal/service/online.go
+++ b/server/rosetta/lib/internal/service/online.go
@@ -26,8 +26,6 @@ func NewOnlineNetwork(network *types.NetworkIdentifier, client crgtypes.Client) 
 		return OnlineNetwork{}, err
 	}*/
 
-	fmt.Println("What")
-
 	block := types.BlockIdentifier{
 		Index: 9283650, // Theta upgrade height
 		Hash:  "0x09E5CC1760C63AB706C79D936024E35AE226D983724F3BB026C4BD1407CDB7FD",

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/simapp
 
-go 1.18
+go 1.19
 
 require (
 	cosmossdk.io/api v0.2.1

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/simapp
 
-go 1.19
+go 1.18
 
 require (
 	cosmossdk.io/api v0.2.1
@@ -155,6 +155,7 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+	github.com/coinbase/rosetta-sdk-go => github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a
 	github.com/cosmos/cosmos-sdk => ../.
 	github.com/cosmos/cosmos-sdk/rosetta => ../server/rosetta
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -171,8 +171,8 @@ github.com/cockroachdb/apd/v2 v2.0.2/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOG
 github.com/cockroachdb/apd/v3 v3.1.0 h1:MK3Ow7LH0W8zkd5GMKA1PvS9qG3bWFI95WaVNfyZJ/w=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/coinbase/rosetta-sdk-go v0.8.1 h1:WE+Temc8iz7Ra7sCpV9ymBJx78vItqFJ2xcSiPet1Pc=
-github.com/coinbase/rosetta-sdk-go v0.8.1/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
+github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a h1:tAQukG4KWS+9jBQs/lkFfKfONI01QJ1YoxnjzHAEh88=
+github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
 github.com/confio/ics23/go v0.7.0 h1:00d2kukk7sPoHWL4zZBZwzxnpA2pec1NPdwbSokJ5w8=
 github.com/confio/ics23/go v0.7.0/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/tests
 
-go 1.19
+go 1.18
 
 require (
 	cosmossdk.io/api v0.2.1
@@ -159,6 +159,7 @@ replace (
 	// We always want to test against the latest version of the simapp.
 	cosmossdk.io/simapp => ../simapp
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+	github.com/coinbase/rosetta-sdk-go => github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a
 	// We always want to test against the latest version of the SDK.
 	github.com/cosmos/cosmos-sdk => ../.
 	github.com/cosmos/cosmos-sdk/rosetta => ../server/rosetta

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/tests
 
-go 1.18
+go 1.19
 
 require (
 	cosmossdk.io/api v0.2.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -171,8 +171,8 @@ github.com/cockroachdb/apd/v2 v2.0.2/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOG
 github.com/cockroachdb/apd/v3 v3.1.0 h1:MK3Ow7LH0W8zkd5GMKA1PvS9qG3bWFI95WaVNfyZJ/w=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/coinbase/rosetta-sdk-go v0.8.1 h1:WE+Temc8iz7Ra7sCpV9ymBJx78vItqFJ2xcSiPet1Pc=
-github.com/coinbase/rosetta-sdk-go v0.8.1/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
+github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a h1:tAQukG4KWS+9jBQs/lkFfKfONI01QJ1YoxnjzHAEh88=
+github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a/go.mod h1:tXPR6AIW9ogsH4tYIaFOKOgfJNanCvcyl7JKLd4DToc=
 github.com/confio/ics23/go v0.7.0 h1:00d2kukk7sPoHWL4zZBZwzxnpA2pec1NPdwbSokJ5w8=
 github.com/confio/ics23/go v0.7.0/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=


### PR DESCRIPTION
Fix the `neither PartialBlockIdentifier.Hash nor PartialBlockIdentifier.Index is set` error message. The new spec allows it now and it should help with `check:spec`.

This PR update the rosetta-sdk-go to a more recent commit.

<!-- ClickUpRef: 31w0gcv -->
:link: [zboto Link](https://app.clickup.com/t/31w0gcv)