### PR TITLE
fix: rosetta cli test

### DIFF
--- a/contrib/rosetta/docker-compose.yaml
+++ b/contrib/rosetta/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3"
 services:
   cosmos:
     image: rosetta-ci:latest
-    command: ["simd", "start", "--pruning", "nothing", "--grpc-web.enable", "true", "--grpc-web.address", "0.0.0.0:9091"]
+    command: ["simd", "start", "--pruning", "nothing", "--grpc.enable", "true", "--grpc.address", "0.0.0.0:9090", "--grpc-web.enable", "true", "--grpc-web.address", "0.0.0.0:9091"]
     ports:
       - 9090:9090
       - 26657:26657
@@ -12,6 +12,8 @@ services:
 
   rosetta:
     image: rosetta-ci:latest
+    depends_on: 
+      - "cosmos"
     command: [
       "simd",
       "rosetta",
@@ -33,6 +35,10 @@ services:
 
   test_rosetta:
     image: rosetta-ci:latest
+    depends_on:
+      - "cosmos"
+      - "rosetta"
+      - "faucet"
     volumes:
       - ./configuration:/rosetta/config:z
     command: ["./config/run_tests.sh"]


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Fix docker-compose used for rosetta-cli tests. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)


<!-- ClickUpRef: 37217kp -->
:link: [zboto Link](https://app.clickup.com/t/37217kp)