### PR TITLE
feat: Migrated bcrypt.GeneratePassword to pdkdf2 and added tests

### DIFF
--- a/crypto/armor.go
+++ b/crypto/armor.go
@@ -223,7 +223,7 @@ func decryptPrivKey(saltBytes []byte, encBytes []byte, passphrase string) (privK
 func decryptSymmetric(encBytes []byte, key []byte) (privKeyBytes []byte, err error) {
 	key = crypto.Sha256(key)
 	privKeyBytes, err = xsalsa20symmetric.DecryptSymmetric(encBytes, key)
-	if err != nil && err.Error() == "Ciphertext decryption failed" {
+	if err != nil && err.Error() == "ciphertext decryption failed" {
 		return privKeyBytes, sdkerrors.ErrWrongPassword
 	} else if err != nil {
 		return privKeyBytes, err

--- a/crypto/armor.go
+++ b/crypto/armor.go
@@ -203,8 +203,8 @@ func decryptPrivKey(saltBytes []byte, encBytes []byte, passphrase string) (privK
 	decryptedPrivBytes, err := decryptSymmetric(encBytes, key)
 	if err == nil && len(decryptedPrivBytes) > 32 {
 		privBytes := decryptedPrivBytes[:len(decryptedPrivBytes)-32]
-		privBytesHash := decryptedPrivBytes[len(decryptedPrivBytes)-32:] //SHA-256 hash is 32 bytes
-		//If the decrypted hash doesn't match the privateBytes hash, then we are working with the old bcrypt algorithm
+		privBytesHash := decryptedPrivBytes[len(decryptedPrivBytes)-32:] // SHA-256 hash is 32 bytes
+		// If the decrypted hash doesn't match the privateBytes hash, then we are working with the old bcrypt algorithm
 		if !bytes.Equal(crypto.Sha256(privBytes), privBytesHash) {
 			privBytes, err = legacyDecryptPrivKey(saltBytes, encBytes, passphrase)
 		}

--- a/crypto/armor_test.go
+++ b/crypto/armor_test.go
@@ -173,13 +173,12 @@ func TestUnarmorInfoBytesErrors(t *testing.T) {
 func BenchmarkBcryptPdkdf2(b *testing.B) {
 	passphrase := []byte("passphrase")
 	for securityParam := uint32(9); securityParam < 16; securityParam++ {
-		var param int = int(securityParam)
-		b.Run(fmt.Sprintf("benchmark-security-param-%d", param), func(b *testing.B) {
+		b.Run(fmt.Sprintf("benchmark-security-param-%d", securityParam), func(b *testing.B) {
 			b.ReportAllocs()
 			saltBytes := cmtcrypto.CRandBytes(16)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				key := pdkdf2.Key([]byte(passphrase), saltBytes, param, 60, sha256.New)
+				key := pdkdf2.Key(passphrase, saltBytes, int(securityParam), 60, sha256.New)
 				require.NotNil(b, key)
 			}
 		})
@@ -221,7 +220,7 @@ func TestBcryptLegacyEncryption(t *testing.T) {
 	require.Equal(t, string(hd.Secp256k1Type), algo)
 	require.True(t, privKey.Equals(decrypted))
 
-	//Latest encryption method
+	// Latest encryption method
 	armored := crypto.EncryptArmorPrivKey(privKey, passphrase, "")
 	_, _, err = crypto.UnarmorDecryptPrivKey(armored, "wrongpassphrase")
 	require.Error(t, err)

--- a/crypto/armor_test.go
+++ b/crypto/armor_test.go
@@ -173,13 +173,13 @@ func TestUnarmorInfoBytesErrors(t *testing.T) {
 func BenchmarkBcryptPdkdf2(b *testing.B) {
 	passphrase := []byte("passphrase")
 	for securityParam := uint32(9); securityParam < 16; securityParam++ {
-		param := securityParam
+		var param int = int(securityParam)
 		b.Run(fmt.Sprintf("benchmark-security-param-%d", param), func(b *testing.B) {
 			b.ReportAllocs()
 			saltBytes := cmtcrypto.CRandBytes(16)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				key := pdkdf2.Key([]byte(passphrase), saltBytes, int(param), 60, sha256.New)
+				key := pdkdf2.Key([]byte(passphrase), saltBytes, param, 60, sha256.New)
 				require.NotNil(b, key)
 			}
 		})
@@ -203,8 +203,8 @@ func TestBcryptLegacyEncryption(t *testing.T) {
 	saltBytes := cmtcrypto.CRandBytes(16)
 	passphrase := "passphrase"
 
-	//Old encryption method
-	key, _ := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), 12) //Legacy Ley gemeratopm
+	// Old encryption method
+	key, _ := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), 12) // Legacy Ley gemeratopm
 	key = cmtcrypto.Sha256(key)                                              // get 32 bytes
 	privKeyBytes := legacy.Cdc.MustMarshal(privKey)
 	encBytes := xsalsa20symmetric.EncryptSymmetric(privKeyBytes, key)

--- a/crypto/armor_test.go
+++ b/crypto/armor_test.go
@@ -2,15 +2,18 @@ package crypto_test
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
 	"testing"
 
 	cmtcrypto "github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/armor"
 	"github.com/cometbft/cometbft/crypto/xsalsa20symmetric"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	pdkdf2 "golang.org/x/crypto/pbkdf2"
 
 	"cosmossdk.io/depinject"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -167,7 +170,7 @@ func TestUnarmorInfoBytesErrors(t *testing.T) {
 	require.Nil(t, unarmoredBytes)
 }
 
-func BenchmarkBcryptGenerateFromPassword(b *testing.B) {
+func BenchmarkBcryptPdkdf2(b *testing.B) {
 	passphrase := []byte("passphrase")
 	for securityParam := uint32(9); securityParam < 16; securityParam++ {
 		param := securityParam
@@ -176,8 +179,8 @@ func BenchmarkBcryptGenerateFromPassword(b *testing.B) {
 			saltBytes := cmtcrypto.CRandBytes(16)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := bcrypt.GenerateFromPassword(saltBytes, passphrase, param)
-				require.Nil(b, err)
+				key := pdkdf2.Key([]byte(passphrase), saltBytes, int(param), 60, sha256.New)
+				require.NotNil(b, key)
 			}
 		})
 	}
@@ -193,4 +196,37 @@ func TestArmor(t *testing.T) {
 	require.Nil(t, err, "%+v", err)
 	assert.Equal(t, blockType, blockType2)
 	assert.Equal(t, data, data2)
+}
+
+func TestBcryptLegacyEncryption(t *testing.T) {
+	privKey := secp256k1.GenPrivKey()
+	saltBytes := cmtcrypto.CRandBytes(16)
+	passphrase := "passphrase"
+
+	//Old encryption method
+	key, _ := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), 12) //Legacy Ley gemeratopm
+	key = cmtcrypto.Sha256(key)                                              // get 32 bytes
+	privKeyBytes := legacy.Cdc.MustMarshal(privKey)
+	encBytes := xsalsa20symmetric.EncryptSymmetric(privKeyBytes, key)
+	header := map[string]string{
+		"kdf":  "bcrypt",
+		"salt": fmt.Sprintf("%X", saltBytes),
+	}
+	armorString := armor.EncodeArmor("TENDERMINT PRIVATE KEY", header, encBytes)
+
+	_, _, err := crypto.UnarmorDecryptPrivKey(armorString, "wrongpassphrase")
+	require.Error(t, err)
+	decrypted, algo, err := crypto.UnarmorDecryptPrivKey(armorString, passphrase)
+	require.NoError(t, err)
+	require.Equal(t, string(hd.Secp256k1Type), algo)
+	require.True(t, privKey.Equals(decrypted))
+
+	//Latest encryption method
+	armored := crypto.EncryptArmorPrivKey(privKey, passphrase, "")
+	_, _, err = crypto.UnarmorDecryptPrivKey(armored, "wrongpassphrase")
+	require.Error(t, err)
+	decrypted, algo, err = crypto.UnarmorDecryptPrivKey(armored, passphrase)
+	require.NoError(t, err)
+	require.Equal(t, string(hd.Secp256k1Type), algo)
+	require.True(t, privKey.Equals(decrypted))
 }

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -115,7 +115,7 @@ func (s *IntegrationTestSuite) TestGRPCServer_Reflection() {
 	// so that we can always assert that given a reflection server it is
 	// possible to fully query all the methods, without having any context
 	// on the proto registry
-	rc := grpcreflect.NewClient(ctx, stub)
+	rc := grpcreflect.NewClientV1Alpha(ctx, stub)
 
 	services, err := rc.ListServices()
 	s.Require().NoError(err)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: [#3129](https://github.com/cosmos/cosmos-sdk/issues/3129)

Replaced bcrypt.GenerateFromPassword usage to pdkdf2 to proper use bcrypt api. Also added logic to decrypt through the GenerateFromPassword to ensure backwards compatibility.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)


<!-- ClickUpRef: 8677hzwde -->
:link: [zboto Link](https://app.clickup.com/t/8677hzwde)